### PR TITLE
Fix configuration path when outside project directory

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -41,18 +41,18 @@ function getAndCheckConfig(extension, fileDirectory) {
   return resolvedConfig
 }
 
-function organizeImports(unsortedCode, filePath) {
+function organizeImports(unsortedCode, extension) {
   // this throw exceptions up to prettier
   const config = getAndCheckConfig(
-    path.extname(filePath),
-    path.dirname(filePath)
+    extension,
+    path.resolve(__dirname, '..', '..')
   )
   const { parser, style, config: rawConfig } = config
   const sortResult = sortImports(
     unsortedCode,
     parser,
     style,
-    filePath,
+    `dummy${extension}`,
     rawConfig.options
   )
   return sortResult.code
@@ -61,14 +61,14 @@ function organizeImports(unsortedCode, filePath) {
 const parsers = {
   typescript: {
     ...typescriptParsers.typescript,
-    preprocess(text, { filepath = 'dummy.ts' }) {
-      return organizeImports(text, filepath)
+    preprocess(text) {
+      return organizeImports(text, '.ts')
     }
   },
   babel: {
     ...javascriptParsers.babel,
-    preprocess(text, { filepath = 'dummy.js' }) {
-      return organizeImports(text, filepath)
+    preprocess(text) {
+      return organizeImports(text, '.js')
     }
   }
 }


### PR DESCRIPTION
When running the plugin from an editor, the current working directory may not be the same as the project directory. Filepath never seems to be passed in as an option, so just fake it with the extension and resolve the directory name to the project directory this is running in.
Note: this assumes that this plugin is installed in a node_modules folder of a project, not globally.