### PR TITLE
Support prettier 2.0

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ const { parsers: typescriptParsers } = _interopDefault(
   require('prettier/parser-typescript')
 )
 const { parsers: javascriptParsers } = _interopDefault(
-  require('prettier/parser-babylon')
+  require('prettier/parser-babel')
 )
 const sortImports = _interopDefault(require('import-sort'))
 const { getConfig } = _interopDefault(require('import-sort-config'))


### PR DESCRIPTION
Support for `parser/babylon` was removed in Prettier 2.0, replaced by `parser/babel`. This change will still support Prettier from v1.16.0.

https://prettier.io/blog/2020/03/21/2.0.0.html#remove-deprecated-options-and-option-values-6993httpsgithubcomprettierprettierpull6993-7511httpsgithubcomprettierprettierpull7511-7533httpsgithubcomprettierprettierpull7533-7535httpsgithubcomprettierprettierpull7535-7536httpsgithubcomprettierprettierpull7536-by-fiskerhttpsgithubcomfisker