### PR TITLE
Use `opts.filepath` as path to the config file

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -41,12 +41,9 @@ function getAndCheckConfig(extension, fileDirectory) {
   return resolvedConfig
 }
 
-function organizeImports(unsortedCode, extension) {
+function organizeImports(unsortedCode, extension, filepath) {
   // this throw exceptions up to prettier
-  const config = getAndCheckConfig(
-    extension,
-    path.resolve(process.cwd())
-  )
+  const config = getAndCheckConfig(extension, filepath)
   const { parser, style, config: rawConfig } = config
   const sortResult = sortImports(
     unsortedCode,
@@ -61,14 +58,13 @@ function organizeImports(unsortedCode, extension) {
 const parsers = {
   typescript: {
     ...typescriptParsers.typescript,
-    preprocess(text) {
-      return organizeImports(text, '.ts')
+    preprocess(text, opts) {
+      return organizeImports(text, '.ts', opts.filepath)
     }
-  },
   babel: {
     ...javascriptParsers.babel,
-    preprocess(text) {
-      return organizeImports(text, '.js')
+    preprocess(text, opts) {
+      return organizeImports(text, '.js', opts.filepath)
     }
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,7 @@ function organizeImports(unsortedCode, extension) {
   // this throw exceptions up to prettier
   const config = getAndCheckConfig(
     extension,
-    path.resolve(__dirname, '..', '..')
+    path.resolve(process.cwd())
   )
   const { parser, style, config: rawConfig } = config
   const sortResult = sortImports(

--- a/src/index.js
+++ b/src/index.js
@@ -61,6 +61,7 @@ const parsers = {
     preprocess(text, opts) {
       return organizeImports(text, '.ts', opts.filepath)
     }
+  },
   babel: {
     ...javascriptParsers.babel,
     preprocess(text, opts) {

--- a/src/index.js
+++ b/src/index.js
@@ -59,7 +59,7 @@ const parsers = {
   typescript: {
     ...typescriptParsers.typescript,
     preprocess(text, opts) {
-      return organizeImports(text, '.ts', opts.filepath)
+      return organizeImports(text, path.extname(opts.filepath), path.dirname(opts.filepath))
     }
   },
   babel: {


### PR DESCRIPTION
It allows to use the plugin even on a monorepo, where `node_modules` folder couldn't be at the same level as the config file.