### PR TITLE
fix: use fallback if filepath not set

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -41,9 +41,12 @@ function getAndCheckConfig(extension, fileDirectory) {
   return resolvedConfig
 }
 
-function organizeImports(unsortedCode, extension, filepath) {
+function organizeImports(unsortedCode, extension, dirname) {
   // this throw exceptions up to prettier
-  const config = getAndCheckConfig(extension, filepath)
+  const config = getAndCheckConfig(
+    extension,
+    dirname || path.resolve(__dirname, '..', '..')
+  )
   const { parser, style, config: rawConfig } = config
   const sortResult = sortImports(
     unsortedCode,
@@ -59,7 +62,15 @@ const parsers = {
   typescript: {
     ...typescriptParsers.typescript,
     preprocess(text, opts) {
-      return organizeImports(text, path.extname(opts.filepath), path.dirname(opts.filepath))
+      let extname = '.ts'
+      let dirname = null
+
+      if (typeof opts.filepath === 'string') {
+        extname = path.extname(opts.filepath)
+        dirname = path.dirname(opts.filepath)
+      }
+
+      return organizeImports(text, extname, dirname)
     }
   },
   babel: {


### PR DESCRIPTION
Since the release 0.0.5 this plugin does not work with https://github.com/neoclide/coc-prettier anymore. The reason is, that the `filepath` property is not provided (see https://github.com/neoclide/coc-prettier/blob/master/src/PrettierEditProvider.ts#L273).

My first attempt was to add the property to the `coc-prettier` library, but from my understanding is the `filepath` property not mandatory (see https://github.com/prettier/prettier/issues/4763#issuecomment-409662425), so it should be catched here in this library.

I added the old way as fallback, if the `filepath` is not set.

Happy to discuss about it!